### PR TITLE
feat: centralize hasura auth

### DIFF
--- a/src/config/hasura.ts
+++ b/src/config/hasura.ts
@@ -1,23 +1,6 @@
 // Configurações do Hasura
+// O endpoint é lido exclusivamente da variável de ambiente HASURA_ENDPOINT
 export const hasuraConfig = {
-  // Endpoint GraphQL
-  endpoint: 'https://neotalks-hasura.t2wird.easypanel.host/v1/graphql',
-  
-  // Chave de admin (você precisa fornecer a chave real)
-  adminSecret: 'mysecretkey', // TODO: Adicionar a chave real aqui
-  
-  // Headers padrão
-  getHeaders: () => {
-    const headers: Record<string, string> = {
-      'Content-Type': 'application/json',
-    };
-    
-    // Se tiver a chave de admin, adicionar
-    if (hasuraConfig.adminSecret) {
-      headers['x-hasura-admin-secret'] = hasuraConfig.adminSecret;
-    }
-    
-    return headers;
-  }
+  endpoint: import.meta.env.VITE_HASURA_ENDPOINT || process.env.HASURA_ENDPOINT || '',
 };
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,13 @@ import react from "@vitejs/plugin-react-swc";
 import path from "path";
 import { componentTagger } from "lovable-tagger";
 
+// Obter endpoint do Hasura do ambiente
+const hasuraEndpoint = process.env.HASURA_ENDPOINT;
+if (!hasuraEndpoint) {
+  throw new Error('HASURA_ENDPOINT is not defined');
+}
+const hasuraUrl = new URL(hasuraEndpoint);
+
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
   server: {
@@ -21,15 +28,13 @@ export default defineConfig(({ mode }) => ({
         secure: true,
       },
       '/graphql': {
-        target: 'https://neotalks-hasura.t2wird.easypanel.host',
+        target: hasuraUrl.origin,
         changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/graphql/, '/v1/graphql'),
+        rewrite: (path) => path.replace(/^\/graphql/, hasuraUrl.pathname),
         secure: true,
         configure: (proxy, _options) => {
           proxy.on('proxyReq', (proxyReq, req, _res) => {
             console.log('📡 GraphQL Request:', req.method, req.url);
-            // Adicionar headers necessários para Hasura
-            // proxyReq.setHeader('x-hasura-admin-secret', 'your-secret-here');
           });
           proxy.on('proxyRes', (proxyRes, req, _res) => {
             console.log('✅ GraphQL Response:', proxyRes.statusCode, req.url);


### PR DESCRIPTION
## Summary
- centralize GraphQL calls through a single client with automatic Bearer token
- read Hasura endpoint from HASURA_ENDPOINT env variable
- proxy GraphQL requests through Vite using env-based target

## Testing
- `npx eslint src/config/hasura.ts src/lib/graphql-client.ts vite.config.ts`
- `HASURA_ENDPOINT=https://example.com/v1/graphql npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b72f361460832a9024384169cb96be