### PR TITLE
feat: add user dropdown with logout

### DIFF
--- a/src/components/DashboardLayout.tsx
+++ b/src/components/DashboardLayout.tsx
@@ -1,13 +1,30 @@
 import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 import { AppSidebar } from "@/components/AppSidebar";
-import { Bell, User } from "lucide-react";
+import { Bell, LogOut, User } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "@/contexts/AuthContext";
 
 interface DashboardLayoutProps {
   children: React.ReactNode;
 }
 
 export function DashboardLayout({ children }: DashboardLayoutProps) {
+  const { user, logout } = useAuth();
+  const navigate = useNavigate();
+
+  const handleLogout = () => {
+    logout();
+    navigate("/login");
+  };
+
   return (
     <SidebarProvider>
       <div className="min-h-screen w-full bg-dashboard-bg">
@@ -20,22 +37,35 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
               <p className="text-sm text-muted-foreground">Painel Administrativo</p>
             </div>
           </div>
-          
+
           <div className="flex items-center gap-3">
             <Button variant="ghost" size="icon">
               <Bell className="w-4 h-4" />
             </Button>
-            <Button variant="ghost" size="icon">
-              <User className="w-4 h-4" />
-            </Button>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="icon">
+                  <User className="w-4 h-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <div className="px-2 py-1.5 text-sm">
+                  <p className="font-medium">{user?.bakery_name}</p>
+                  <p className="text-muted-foreground text-xs">{user?.email}</p>
+                </div>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={handleLogout}>
+                  <LogOut className="mr-2 h-4 w-4" />
+                  Sair
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
         </header>
 
         <div className="flex w-full">
           <AppSidebar />
-          <main className="flex-1 p-6">
-            {children}
-          </main>
+          <main className="flex-1 p-6">{children}</main>
         </div>
       </div>
     </SidebarProvider>

--- a/src/components/padaria/CriarPadariaModal.tsx
+++ b/src/components/padaria/CriarPadariaModal.tsx
@@ -87,19 +87,19 @@ export function CriarPadariaModal({ children }: CriarPadariaModalProps) {
       
       setOpen(false);
       form.reset();
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Error creating bakery:", error);
-      
+
       let errorMessage = "Tente novamente ou contate o suporte.";
-      
-      if (error.message) {
+
+      if (error instanceof Error && error.message) {
         if (error.message.includes('duplicate') || error.message.includes('already exists')) {
           errorMessage = "Este CNPJ já está cadastrado no sistema.";
         } else {
           errorMessage = error.message;
         }
       }
-      
+
       toast.error("Erro ao criar padaria", {
         description: errorMessage,
       });

--- a/src/components/padaria/EditarPadariaModal.tsx
+++ b/src/components/padaria/EditarPadariaModal.tsx
@@ -134,10 +134,10 @@ export function EditarPadariaModal({ children, bakery, onUpdate }: EditarPadaria
       }
       
       setOpen(false);
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Error updating padaria:', error);
       toast.error("Erro ao atualizar padaria", {
-        description: error.message || "Tente novamente ou contate o suporte.",
+        description: error instanceof Error ? error.message : "Tente novamente ou contate o suporte.",
       });
     } finally {
       setIsSubmitting(false);

--- a/src/components/padaria/ExcluirPadariaModal.tsx
+++ b/src/components/padaria/ExcluirPadariaModal.tsx
@@ -38,10 +38,10 @@ export function ExcluirPadariaModal({ children, padaria }: ExcluirPadariaModalPr
       toast.success("Padaria excluída com sucesso!", {
         description: `${padaria.nome} foi removida do sistema.`,
       });
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Error deleting padaria:', error);
       toast.error("Erro ao excluir padaria", {
-        description: error.message || "Tente novamente ou contate o suporte.",
+        description: error instanceof Error ? error.message : "Tente novamente ou contate o suporte.",
       });
     } finally {
       setIsDeleting(false);

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -143,14 +143,14 @@ export function AuthProvider({ children }: AuthProviderProps) {
             // Em produção, você deve implementar verificação de senha adequada
             if (hasuraUser.role === 'admin') {
               // Simular usuário SINDPAN para compatibilidade
-              const mockSindpanUser = {
+              const mockSindpanUser: SindpanUser = {
                 id: hasuraUser.id,
                 email: hasuraUser.email,
                 bakery_name: hasuraUser.bakery_name,
                 role: hasuraUser.role
               };
-              
-              setSindpanUser(mockSindpanUser as any);
+
+              setSindpanUser(mockSindpanUser);
               
               toast.success('Login realizado com sucesso', {
                 description: 'Bem-vindo ao painel administrativo!',

--- a/src/hooks/useGraphQL.ts
+++ b/src/hooks/useGraphQL.ts
@@ -2,10 +2,10 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { graphqlClient } from '@/lib/graphql-client';
 
 // Hook para queries GraphQL
-export const useGraphQLQuery = <T = any>(
+export const useGraphQLQuery = <T = unknown>(
   queryKey: string[],
   query: string,
-  variables?: Record<string, any>,
+  variables?: Record<string, unknown>,
   options?: {
     enabled?: boolean;
     refetchInterval?: number;
@@ -25,7 +25,10 @@ export const useGraphQLQuery = <T = any>(
 };
 
 // Hook para mutations GraphQL
-export const useGraphQLMutation = <T = any, V = Record<string, any>>(
+export const useGraphQLMutation = <
+  T = unknown,
+  V extends Record<string, unknown> = Record<string, unknown>
+>(
   mutation: string,
   options?: {
     onSuccess?: (data: T) => void;
@@ -37,7 +40,7 @@ export const useGraphQLMutation = <T = any, V = Record<string, any>>(
 
   return useMutation({
     mutationFn: async (variables: V) => {
-      const result = await graphqlClient.mutate<T>(mutation, variables as Record<string, any>);
+      const result = await graphqlClient.mutate<T>(mutation, variables);
       return result;
     },
     onSuccess: (data) => {

--- a/src/utils/apiTestUtils.ts
+++ b/src/utils/apiTestUtils.ts
@@ -5,7 +5,7 @@ export interface TestResult {
   endpoint: string;
   status: 'success' | 'error';
   message: string;
-  response?: any;
+  response?: unknown;
   error?: string;
 }
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -191,5 +192,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [tailwindcssAnimate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add auth-aware user dropdown with logout navigation
- replace remaining any types and require imports to satisfy eslint

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: HASURA_ENDPOINT is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68bb36b475f4832abb6540d23035c0e4