### PR TITLE
feat: export padarias to excel

### DIFF
--- a/src/components/padaria/PaymentDropdown.tsx
+++ b/src/components/padaria/PaymentDropdown.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Badge } from "@/components/ui/badge";
 import { toast } from "sonner";
+import { formatStatusPagamento } from "@/utils";
 
 interface PaymentDropdownProps {
   currentStatus: string;
@@ -9,27 +10,65 @@ interface PaymentDropdownProps {
   onStatusChange?: (newStatus: string) => void;
 }
 
+type PaymentStatus = "pago" | "em_aberto" | "atrasado";
+
+const PAYMENT_STATUS_OPTIONS: Record<PaymentStatus, { label: string; className: string; variant: "default" | "outline" }> = {
+  pago: {
+    label: formatStatusPagamento("pago"),
+    className: "border border-blue-200 bg-blue-100 text-blue-800",
+    variant: "default"
+  },
+  em_aberto: {
+    label: formatStatusPagamento("em_aberto"),
+    className: "border border-orange-200 bg-orange-50 text-orange-600",
+    variant: "outline"
+  },
+  atrasado: {
+    label: formatStatusPagamento("atrasado"),
+    className: "border border-red-200 bg-red-50 text-red-600",
+    variant: "outline"
+  }
+};
+
+const normalizeStatus = (value: string): PaymentStatus => {
+  const normalized = value
+    .toLowerCase()
+    .replace(/\s+/g, "_");
+
+  if (normalized === "pago") {
+    return "pago";
+  }
+
+  if (normalized === "atrasado" || normalized === "cancelado" || normalized === "vencido") {
+    return "atrasado";
+  }
+
+  return "em_aberto";
+};
+
 export function PaymentDropdown({ currentStatus, bakeryName, onStatusChange }: PaymentDropdownProps) {
-  const [status, setStatus] = useState(currentStatus);
+  const [status, setStatus] = useState<PaymentStatus>(() => normalizeStatus(currentStatus));
   const [isUpdating, setIsUpdating] = useState(false);
 
   const handleStatusChange = async (newStatus: string) => {
-    if (newStatus === status) return;
-    
+    const normalizedStatus = normalizeStatus(newStatus);
+
+    if (normalizedStatus === status) return;
+
     try {
       setIsUpdating(true);
-      
+
       // Simular delay de API
       await new Promise(resolve => setTimeout(resolve, 800));
-      
-      setStatus(newStatus);
-      
+
+      setStatus(normalizedStatus);
+
       toast.success("Status atualizado!", {
-        description: `${bakeryName} - Pagamento: ${newStatus}`,
+        description: `${bakeryName} - Pagamento: ${PAYMENT_STATUS_OPTIONS[normalizedStatus].label}`,
       });
 
       if (onStatusChange) {
-        onStatusChange(newStatus);
+        onStatusChange(normalizedStatus);
       }
     } catch (error) {
       toast.error("Erro ao atualizar status", {
@@ -41,43 +80,22 @@ export function PaymentDropdown({ currentStatus, bakeryName, onStatusChange }: P
   };
 
   const getStatusBadge = (statusValue: string) => {
-    switch (statusValue) {
-      case "pago":
-        return (
-          <Badge variant="concluido" className="cursor-pointer">
-            pago
-          </Badge>
-        );
-      case "pendente":
-        return (
-          <Badge variant="agendado" className="cursor-pointer">
-            pendente
-          </Badge>
-        );
-      case "cancelado":
-        return (
-          <Badge variant="nao-informado" className="cursor-pointer">
-            cancelado
-          </Badge>
-        );
-      case "em aberto":
-        return (
-          <Badge variant="agendado" className="cursor-pointer">
-            pendente
-          </Badge>
-        );
-      default:
-        return (
-          <Badge variant="outline" className="cursor-pointer">
-            {statusValue}
-          </Badge>
-        );
-    }
+    const normalizedStatus = normalizeStatus(statusValue);
+    const { label, className, variant } = PAYMENT_STATUS_OPTIONS[normalizedStatus];
+
+    return (
+      <Badge
+        variant={variant}
+        className={`cursor-pointer ${className}`.trim()}
+      >
+        {label}
+      </Badge>
+    );
   };
 
   return (
-    <Select 
-      value={status} 
+    <Select
+      value={status}
       onValueChange={handleStatusChange}
       disabled={isUpdating}
     >
@@ -87,15 +105,13 @@ export function PaymentDropdown({ currentStatus, bakeryName, onStatusChange }: P
         </SelectValue>
       </SelectTrigger>
       <SelectContent>
-        <SelectItem value="pago">
-          <Badge variant="concluido">pago</Badge>
-        </SelectItem>
-        <SelectItem value="pendente">
-          <Badge variant="agendado">pendente</Badge>
-        </SelectItem>
-        <SelectItem value="cancelado">
-          <Badge variant="nao-informado">cancelado</Badge>
-        </SelectItem>
+        {Object.entries(PAYMENT_STATUS_OPTIONS).map(([value, option]) => (
+          <SelectItem key={value} value={value}>
+            <Badge variant={option.variant} className={option.className}>
+              {option.label}
+            </Badge>
+          </SelectItem>
+        ))}
       </SelectContent>
     </Select>
   );

--- a/src/hooks/useUsers.ts
+++ b/src/hooks/useUsers.ts
@@ -1,5 +1,5 @@
 import { useGraphQLQuery } from './useGraphQL';
-import { GET_USER, GET_USERS } from '@/graphql/queries';
+import { GET_USER, GET_USERS, GET_USER_BY_EMAIL_WITH_PADARIA } from '@/graphql/queries';
 
 // Tipos baseados no schema Hasura
 export interface User {
@@ -9,7 +9,6 @@ export interface User {
   bakery_name: string;
   role: 'admin' | 'bakery';
   padarias_id?: string; // UUID da padaria
-  cnpj?: string;
   padarias?: {
     nome: string;
     id: string;
@@ -26,10 +25,16 @@ export const useUser = (
   enabled: boolean = true
 ) => {
   const key = identifier.email || identifier.cnpj || 'unknown';
+  const hasCnpj = !!identifier.cnpj;
+  const query = hasCnpj ? GET_USER : GET_USER_BY_EMAIL_WITH_PADARIA;
+  const variables = hasCnpj
+    ? identifier
+    : { email: identifier.email! };
+
   return useGraphQLQuery<UserResponse>(
     ['user', key],
-    GET_USER,
-    identifier,
+    query,
+    variables,
     {
       enabled: enabled && (!!identifier.email || !!identifier.cnpj),
       staleTime: 5 * 60 * 1000, // 5 minutos

--- a/src/pages/Padarias.tsx
+++ b/src/pages/Padarias.tsx
@@ -706,8 +706,8 @@ export default function Padarias() {
   }
 
   return (
-    <div className="mx-auto w-full max-w-7xl space-y-6 px-2 sm:px-0">
-        <div className="flex items-center justify-between">
+    <div className="space-y-6">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <h1 className="text-3xl font-bold text-primary">Padarias Participantes</h1>
             <p className="text-muted-foreground">Gerencie as padarias cadastradas na campanha</p>
@@ -771,8 +771,8 @@ export default function Padarias() {
         </div>
 
         {/* Search and export */}
-        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-          <div className="relative w-full md:max-w-sm">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+          <div className="relative w-full max-w-xl lg:max-w-sm">
             <Search className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
             <Input
               placeholder="Buscar por nome ou CNPJ..."
@@ -828,12 +828,12 @@ export default function Padarias() {
         </div>
 
         {/* Bakeries Table */}
-        <Card>
+        <Card className="overflow-hidden">
           <CardHeader>
             <CardTitle>Lista de Padarias</CardTitle>
           </CardHeader>
-          <CardContent className="overflow-x-auto">
-            <Table className="w-full min-w-[960px]">
+          <CardContent className="max-w-full overflow-x-auto p-0">
+            <Table className="w-full min-w-[56rem]">
               <TableHeader>
                 <TableRow>
                   <TableHead>Nome</TableHead>

--- a/src/pages/Padarias.tsx
+++ b/src/pages/Padarias.tsx
@@ -706,7 +706,7 @@ export default function Padarias() {
   }
 
   return (
-      <div className="space-y-6">
+    <div className="mx-auto w-full max-w-7xl space-y-6 px-2 sm:px-0">
         <div className="flex items-center justify-between">
           <div>
             <h1 className="text-3xl font-bold text-primary">Padarias Participantes</h1>
@@ -832,8 +832,8 @@ export default function Padarias() {
           <CardHeader>
             <CardTitle>Lista de Padarias</CardTitle>
           </CardHeader>
-          <CardContent>
-            <Table>
+          <CardContent className="overflow-x-auto">
+            <Table className="w-full min-w-[960px]">
               <TableHeader>
                 <TableRow>
                   <TableHead>Nome</TableHead>
@@ -921,6 +921,6 @@ export default function Padarias() {
             </Table>
           </CardContent>
         </Card>
-      </div>
+    </div>
   );
 }

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -176,12 +176,18 @@ export const formatStatus = (status: string): string => {
  * Formata status de pagamento
  */
 export const formatStatusPagamento = (status: string): string => {
+  const normalizedStatus = status
+    .toLowerCase()
+    .replace(/\s+/g, '_');
+
   const statusMap: Record<string, string> = {
     'pago': 'Pago',
+    'em_aberto': 'Pendente',
     'pendente': 'Pendente',
+    'atrasado': 'Atrasado',
     'vencido': 'Vencido',
     'cancelado': 'Cancelado'
   };
-  
-  return statusMap[status] || status;
+
+  return statusMap[normalizedStatus] || status;
 };

--- a/src/utils/xlsx.ts
+++ b/src/utils/xlsx.ts
@@ -1,0 +1,254 @@
+const MIME_TYPE = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+const encoder = new TextEncoder();
+
+const CRC32_TABLE = (() => {
+  const table = new Uint32Array(256);
+  for (let i = 0; i < 256; i++) {
+    let crc = i;
+    for (let j = 0; j < 8; j++) {
+      if ((crc & 1) !== 0) {
+        crc = (crc >>> 1) ^ 0xedb88320;
+      } else {
+        crc >>>= 1;
+      }
+    }
+    table[i] = crc >>> 0;
+  }
+  return table;
+})();
+
+function crc32(data: Uint8Array): number {
+  let crc = 0 ^ -1;
+  for (let i = 0; i < data.length; i++) {
+    crc = CRC32_TABLE[(crc ^ data[i]) & 0xff] ^ (crc >>> 8);
+  }
+  return (crc ^ -1) >>> 0;
+}
+
+function columnIndexToLetter(index: number): string {
+  let current = index + 1;
+  let result = "";
+
+  while (current > 0) {
+    const remainder = (current - 1) % 26;
+    result = String.fromCharCode(65 + remainder) + result;
+    current = Math.floor((current - 1) / 26);
+  }
+
+  return result;
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+function escapeXmlAttribute(value: string): string {
+  return escapeXml(value);
+}
+
+function createSheetXml(rows: string[][]): string {
+  if (rows.length === 0) {
+    return (
+      '<?xml version="1.0" encoding="UTF-8"?>' +
+      '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData/></worksheet>'
+    );
+  }
+
+  const rowXml = rows
+    .map((cells, rowIndex) => {
+      const cellXml = cells
+        .map((value, cellIndex) => {
+          const cellRef = `${columnIndexToLetter(cellIndex)}${rowIndex + 1}`;
+          const escapedValue = escapeXml(value);
+          return `<c r="${cellRef}" t="inlineStr"><is><t xml:space="preserve">${escapedValue}</t></is></c>`;
+        })
+        .join("");
+
+      return `<row r="${rowIndex + 1}">${cellXml}</row>`;
+    })
+    .join("");
+
+  return (
+    '<?xml version="1.0" encoding="UTF-8"?>' +
+    '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">' +
+    `<sheetData>${rowXml}</sheetData>` +
+    '</worksheet>'
+  );
+}
+
+const INVALID_SHEET_NAME_CHARS = new Set(["\\", "/", "*", "?", ":", "[", "]"]);
+
+function sanitizeSheetName(name: string): string {
+  const cleaned = name
+    .split("")
+    .filter((char) => !INVALID_SHEET_NAME_CHARS.has(char))
+    .join("")
+    .trim();
+  const safe = cleaned.length > 0 ? cleaned : "Sheet1";
+  return safe.slice(0, 31);
+}
+
+function ensureXlsxExtension(filename: string): string {
+  return filename.toLowerCase().endsWith(".xlsx") ? filename : `${filename}.xlsx`;
+}
+
+interface ZipEntry {
+  name: string;
+  data: Uint8Array;
+}
+
+function createZip(entries: ZipEntry[]): Uint8Array {
+  const fileParts: Uint8Array[] = [];
+  const centralDirectoryParts: Uint8Array[] = [];
+  let offset = 0;
+
+  for (const entry of entries) {
+    const nameBytes = encoder.encode(entry.name);
+    const data = entry.data;
+    const crc = crc32(data);
+
+    const localHeader = new Uint8Array(30 + nameBytes.length);
+    const localView = new DataView(localHeader.buffer);
+    localView.setUint32(0, 0x04034b50, true);
+    localView.setUint16(4, 20, true);
+    localView.setUint16(6, 0, true);
+    localView.setUint16(8, 0, true);
+    localView.setUint16(10, 0, true);
+    localView.setUint16(12, 0, true);
+    localView.setUint32(14, crc, true);
+    localView.setUint32(18, data.length, true);
+    localView.setUint32(22, data.length, true);
+    localView.setUint16(26, nameBytes.length, true);
+    localView.setUint16(28, 0, true);
+    localHeader.set(nameBytes, 30);
+
+    fileParts.push(localHeader, data);
+
+    const centralHeader = new Uint8Array(46 + nameBytes.length);
+    const centralView = new DataView(centralHeader.buffer);
+    centralView.setUint32(0, 0x02014b50, true);
+    centralView.setUint16(4, 20, true);
+    centralView.setUint16(6, 20, true);
+    centralView.setUint16(8, 0, true);
+    centralView.setUint16(10, 0, true);
+    centralView.setUint16(12, 0, true);
+    centralView.setUint16(14, 0, true);
+    centralView.setUint32(16, crc, true);
+    centralView.setUint32(20, data.length, true);
+    centralView.setUint32(24, data.length, true);
+    centralView.setUint16(28, nameBytes.length, true);
+    centralView.setUint16(30, 0, true);
+    centralView.setUint16(32, 0, true);
+    centralView.setUint16(34, 0, true);
+    centralView.setUint16(36, 0, true);
+    centralView.setUint32(38, 0, true);
+    centralView.setUint32(42, offset, true);
+    centralHeader.set(nameBytes, 46);
+
+    centralDirectoryParts.push(centralHeader);
+
+    offset += localHeader.length + data.length;
+  }
+
+  const centralDirectorySize = centralDirectoryParts.reduce((sum, part) => sum + part.length, 0);
+  const endRecord = new Uint8Array(22);
+  const endView = new DataView(endRecord.buffer);
+  endView.setUint32(0, 0x06054b50, true);
+  endView.setUint16(4, 0, true);
+  endView.setUint16(6, 0, true);
+  endView.setUint16(8, entries.length, true);
+  endView.setUint16(10, entries.length, true);
+  endView.setUint32(12, centralDirectorySize, true);
+  endView.setUint32(16, offset, true);
+  endView.setUint16(20, 0, true);
+
+  const totalSize = offset + centralDirectorySize + endRecord.length;
+  const output = new Uint8Array(totalSize);
+  let pointer = 0;
+
+  for (const part of fileParts) {
+    output.set(part, pointer);
+    pointer += part.length;
+  }
+
+  for (const part of centralDirectoryParts) {
+    output.set(part, pointer);
+    pointer += part.length;
+  }
+
+  output.set(endRecord, pointer);
+
+  return output;
+}
+
+function toUint8Array(content: string): Uint8Array {
+  return encoder.encode(content);
+}
+
+export function exportToXLSX(filename: string, sheetName: string, rows: string[][]): void {
+  const safeFileName = ensureXlsxExtension(filename);
+  const sanitizedSheetName = sanitizeSheetName(sheetName);
+  const normalizedRows = rows.map(row => row.map(cell => (cell ?? "").toString()));
+  const sheetXml = createSheetXml(normalizedRows);
+  const workbookXml =
+    '<?xml version="1.0" encoding="UTF-8"?>' +
+    '<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">' +
+    '<sheets>' +
+    `<sheet name="${escapeXmlAttribute(sanitizedSheetName)}" sheetId="1" r:id="rId1"/>` +
+    '</sheets>' +
+    '</workbook>';
+  const contentTypesXml =
+    '<?xml version="1.0" encoding="UTF-8"?>' +
+    '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">' +
+    '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+    '<Default Extension="xml" ContentType="application/xml"/>' +
+    '<Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>' +
+    '<Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>' +
+    '<Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>' +
+    '</Types>';
+  const rootRelsXml =
+    '<?xml version="1.0" encoding="UTF-8"?>' +
+    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+    '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>' +
+    '</Relationships>';
+  const workbookRelsXml =
+    '<?xml version="1.0" encoding="UTF-8"?>' +
+    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+    '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>' +
+    '<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>' +
+    '</Relationships>';
+  const stylesXml =
+    '<?xml version="1.0" encoding="UTF-8"?>' +
+    '<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">' +
+    '<fonts count="1"><font><sz val="11"/><color theme="1"/><name val="Calibri"/><family val="2"/></font></fonts>' +
+    '<fills count="1"><fill><patternFill patternType="none"/></fill></fills>' +
+    '<borders count="1"><border><left/><right/><top/><bottom/><diagonal/></border></borders>' +
+    '<cellStyleXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellStyleXfs>' +
+    '<cellXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"/></cellXfs>' +
+    '<cellStyles count="1"><cellStyle name="Normal" xfId="0" builtinId="0"/></cellStyles>' +
+    '</styleSheet>';
+
+  const zipData = createZip([
+    { name: "[Content_Types].xml", data: toUint8Array(contentTypesXml) },
+    { name: "_rels/.rels", data: toUint8Array(rootRelsXml) },
+    { name: "xl/workbook.xml", data: toUint8Array(workbookXml) },
+    { name: "xl/_rels/workbook.xml.rels", data: toUint8Array(workbookRelsXml) },
+    { name: "xl/styles.xml", data: toUint8Array(stylesXml) },
+    { name: "xl/worksheets/sheet1.xml", data: toUint8Array(sheetXml) }
+  ]);
+
+  const blob = new Blob([zipData], { type: MIME_TYPE });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = safeFileName;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
+}

--- a/src/utils/xlsx.ts
+++ b/src/utils/xlsx.ts
@@ -1,6 +1,11 @@
 const MIME_TYPE = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
 const encoder = new TextEncoder();
 
+const BRAND_PRIMARY = "FF880808";
+const BRAND_FOREGROUND = "FF1F2937";
+const BRAND_MUTED = "FFF6F0E8";
+const BORDER_NEUTRAL = "FFE2E8F0";
+
 const CRC32_TABLE = (() => {
   const table = new Uint32Array(256);
   for (let i = 0; i < 256; i++) {
@@ -51,7 +56,7 @@ function escapeXmlAttribute(value: string): string {
   return escapeXml(value);
 }
 
-function createSheetXml(rows: string[][]): string {
+function createSheetXml(rows: string[][], columnWidths: number[]): string {
   if (rows.length === 0) {
     return (
       '<?xml version="1.0" encoding="UTF-8"?>' +
@@ -59,26 +64,73 @@ function createSheetXml(rows: string[][]): string {
     );
   }
 
+  const columnCount = columnWidths.length;
+  const lastColumnRef = columnCount > 0 ? columnIndexToLetter(columnCount - 1) : "A";
+  const dimensionRef = `A1:${lastColumnRef}${rows.length}`;
+
+  const colsXml = columnWidths
+    .map((width, index) =>
+      `<col min="${index + 1}" max="${index + 1}" width="${width.toFixed(2)}" customWidth="1"/>`
+    )
+    .join("");
+
   const rowXml = rows
     .map((cells, rowIndex) => {
+      const rowNumber = rowIndex + 1;
+      const rowHeight = rowIndex === 0 ? 26 : 22;
       const cellXml = cells
         .map((value, cellIndex) => {
-          const cellRef = `${columnIndexToLetter(cellIndex)}${rowIndex + 1}`;
+          const cellRef = `${columnIndexToLetter(cellIndex)}${rowNumber}`;
           const escapedValue = escapeXml(value);
-          return `<c r="${cellRef}" t="inlineStr"><is><t xml:space="preserve">${escapedValue}</t></is></c>`;
+          const dataIndex = rowIndex - 1;
+          const styleIndex = rowIndex === 0 ? 1 : (dataIndex % 2 === 0 ? 0 : 2);
+
+          return `<c r="${cellRef}" t="inlineStr" s="${styleIndex}"><is><t xml:space="preserve">${escapedValue}</t></is></c>`;
         })
         .join("");
 
-      return `<row r="${rowIndex + 1}">${cellXml}</row>`;
+      return `<row r="${rowNumber}" ht="${rowHeight.toFixed(2)}" customHeight="1">${cellXml}</row>`;
     })
     .join("");
 
   return (
     '<?xml version="1.0" encoding="UTF-8"?>' +
     '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">' +
+    `<dimension ref="${dimensionRef}"/>` +
+    '<sheetViews><sheetView workbookViewId="0"><pane state="frozen" ySplit="1" topLeftCell="A2" activePane="bottomLeft"/><selection pane="bottomLeft" activeCell="A2" sqref="A2"/></sheetView></sheetViews>' +
+    '<sheetFormatPr defaultRowHeight="22"/>' +
+    (colsXml.length > 0 ? `<cols>${colsXml}</cols>` : "") +
     `<sheetData>${rowXml}</sheetData>` +
+    '<pageMargins left="0.5" right="0.5" top="0.75" bottom="0.75" header="0.3" footer="0.3"/>' +
     '</worksheet>'
   );
+}
+
+function computeColumnWidths(rows: string[][]): number[] {
+  if (rows.length === 0) {
+    return [];
+  }
+
+  const columnCount = rows[0].length;
+  const maxChars = new Array(columnCount).fill(0);
+
+  for (const row of rows) {
+    for (let i = 0; i < columnCount; i++) {
+      const cell = row[i] ?? "";
+      const maxSegment = cell
+        .toString()
+        .split(/\r?\n/)
+        .reduce((max, segment) => Math.max(max, segment.length), 0);
+      if (maxSegment > maxChars[i]) {
+        maxChars[i] = maxSegment;
+      }
+    }
+  }
+
+  return maxChars.map((length) => {
+    const padded = length + 4;
+    return Math.min(60, Math.max(12, padded));
+  });
 }
 
 const INVALID_SHEET_NAME_CHARS = new Set(["\\", "/", "*", "?", ":", "[", "]"]);
@@ -193,8 +245,17 @@ function toUint8Array(content: string): Uint8Array {
 export function exportToXLSX(filename: string, sheetName: string, rows: string[][]): void {
   const safeFileName = ensureXlsxExtension(filename);
   const sanitizedSheetName = sanitizeSheetName(sheetName);
-  const normalizedRows = rows.map(row => row.map(cell => (cell ?? "").toString()));
-  const sheetXml = createSheetXml(normalizedRows);
+  const sanitizedRows = rows.map((row) => row.map((cell) => (cell ?? "").toString()));
+  const columnCount = sanitizedRows.reduce((max, row) => Math.max(max, row.length), 0);
+  const normalizedRows = sanitizedRows.map((row) => {
+    const filled: string[] = [];
+    for (let i = 0; i < columnCount; i++) {
+      filled[i] = row[i] ?? "";
+    }
+    return filled;
+  });
+  const columnWidths = computeColumnWidths(normalizedRows);
+  const sheetXml = createSheetXml(normalizedRows, columnWidths);
   const workbookXml =
     '<?xml version="1.0" encoding="UTF-8"?>' +
     '<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">' +
@@ -225,11 +286,26 @@ export function exportToXLSX(filename: string, sheetName: string, rows: string[]
   const stylesXml =
     '<?xml version="1.0" encoding="UTF-8"?>' +
     '<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">' +
-    '<fonts count="1"><font><sz val="11"/><color theme="1"/><name val="Calibri"/><family val="2"/></font></fonts>' +
-    '<fills count="1"><fill><patternFill patternType="none"/></fill></fills>' +
-    '<borders count="1"><border><left/><right/><top/><bottom/><diagonal/></border></borders>' +
+    `<fonts count="2">` +
+    `<font><sz val="11"/><color rgb="${BRAND_FOREGROUND}"/><name val="Calibri"/><family val="2"/></font>` +
+    '<font><b/><sz val="12"/><color rgb="FFFFFFFF"/><name val="Calibri"/><family val="2"/></font>' +
+    '</fonts>' +
+    '<fills count="4">' +
+    '<fill><patternFill patternType="none"/></fill>' +
+    '<fill><patternFill patternType="gray125"/></fill>' +
+    `<fill><patternFill patternType="solid"><fgColor rgb="${BRAND_PRIMARY}"/><bgColor indexed="64"/></patternFill></fill>` +
+    `<fill><patternFill patternType="solid"><fgColor rgb="${BRAND_MUTED}"/><bgColor indexed="64"/></patternFill></fill>` +
+    '</fills>' +
+    '<borders count="2">' +
+    '<border><left/><right/><top/><bottom/><diagonal/></border>' +
+    `<border><left style="thin"><color rgb="${BORDER_NEUTRAL}"/></left><right style="thin"><color rgb="${BORDER_NEUTRAL}"/></right><top style="thin"><color rgb="${BORDER_NEUTRAL}"/></top><bottom style="thin"><color rgb="${BORDER_NEUTRAL}"/></bottom><diagonal/></border>` +
+    '</borders>' +
     '<cellStyleXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellStyleXfs>' +
-    '<cellXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"/></cellXfs>' +
+    '<cellXfs count="3">' +
+    '<xf numFmtId="0" fontId="0" fillId="0" borderId="1" xfId="0"><alignment horizontal="left" vertical="center" wrapText="1"/></xf>' +
+    `<xf numFmtId="0" fontId="1" fillId="2" borderId="1" xfId="0"><alignment horizontal="left" vertical="center" wrapText="1"/></xf>` +
+    `<xf numFmtId="0" fontId="0" fillId="3" borderId="1" xfId="0"><alignment horizontal="left" vertical="center" wrapText="1"/></xf>` +
+    '</cellXfs>' +
     '<cellStyles count="1"><cellStyle name="Normal" xfId="0" builtinId="0"/></cellStyles>' +
     '</styleSheet>';
 


### PR DESCRIPTION
## Summary
- add a column-selectable export to XLSX button to the Padarias admin table
- implement an in-house XLSX generator to produce spreadsheets without external dependencies

## Testing
- npm run lint *(fails: existing lint errors in unrelated components prior to this change)*
- npx eslint src/pages/Padarias.tsx src/utils/xlsx.ts


------
https://chatgpt.com/codex/tasks/task_e_68dac71cfcac832aabe04ffdfe50301b