### PR TITLE
Adicionar número da sorte e série ao relatório de participação

### DIFF
--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -612,6 +612,9 @@ export const GET_ALL_CLIENTES_WITH_CUPONS = `
       id
       nome
       cpf
+      padaria {
+        nome
+      }
       padaria_id
       whatsapp
       resposta_pergunta
@@ -619,6 +622,8 @@ export const GET_ALL_CLIENTES_WITH_CUPONS = `
         cliente_id
         data_compra
         id
+        numero_sorte
+        serie
       }
     }
   }

--- a/src/pages/Relatorios.tsx
+++ b/src/pages/Relatorios.tsx
@@ -15,6 +15,7 @@ import { toast } from "sonner";
 import { useState } from "react";
 import jsPDF from "jspdf";
 import * as XLSX from "xlsx";
+import { exportToXLSX } from "@/utils/xlsx";
 
 export default function Relatorios() {
   const [isExporting, setIsExporting] = useState(false);
@@ -115,21 +116,11 @@ export default function Relatorios() {
         }
       });
 
-      const wb = XLSX.utils.book_new();
-      const ws = XLSX.utils.aoa_to_sheet(worksheetData);
-
-      ws["!cols"] = [
-        { wch: 30 }, // Cliente
-        { wch: 16 }, // CPF
-        { wch: 18 }, // Número da Sorte
-        { wch: 8 },  // Série
-        { wch: 18 }, // WhatsApp
-        { wch: 30 }, // Padaria
-        { wch: 14 }  // Data da Compra
-      ];
-
-      XLSX.utils.book_append_sheet(wb, ws, "Participação");
-      XLSX.writeFile(wb, `relatorio_participacao_${new Date().toISOString().split("T")[0]}.xlsx`);
+      exportToXLSX(
+        `relatorio_participacao_${new Date().toISOString().split("T")[0]}.xlsx`,
+        "Participação",
+        worksheetData
+      );
 
       toast.success(`Relatório exportado com ${worksheetData.length - 1} registros!`);
     } catch (error) {

--- a/src/pages/Relatorios.tsx
+++ b/src/pages/Relatorios.tsx
@@ -66,19 +66,14 @@ export default function Relatorios() {
         clientes: Array<{
           nome: string;
           cpf: string;
-          telefone: string;
-          email: string;
+          whatsapp: string;
+          padaria: {
+            nome: string;
+          } | null;
           cupons: Array<{
-            numero_cupom: string;
             numero_sorte: string | null;
-            created_at: string;
-            sorteio: {
-              nome: string;
-              data_sorteio: string;
-            } | null;
-            padaria: {
-              nome: string;
-            };
+            serie: number | null;
+            data_compra: string | null;
           }>;
         }>;
       }>(GET_ALL_CLIENTES_WITH_CUPONS);
@@ -97,14 +92,11 @@ export default function Relatorios() {
               rows.push([
                 `"${cliente.nome || 'N/A'}"`,
                 cliente.cpf || 'N/A',
-                cliente.telefone || 'N/A',
-                cliente.email || 'N/A',
-                cupom.numero_cupom || 'N/A',
                 cupom.numero_sorte || "N/A",
-                cupom.sorteio?.nome ? `"${cupom.sorteio.nome}"` : "N/A",
-                cupom.sorteio?.data_sorteio ? new Date(cupom.sorteio.data_sorteio).toLocaleDateString('pt-BR') : "N/A",
-                cupom.padaria?.nome ? `"${cupom.padaria.nome}"` : "N/A",
-                cupom.created_at ? new Date(cupom.created_at).toLocaleDateString('pt-BR') : 'N/A'
+                cupom.serie?.toString() || "N/A",
+                cliente.whatsapp || 'N/A',
+                cliente.padaria?.nome ? `"${cliente.padaria.nome}"` : "N/A",
+                cupom.data_compra ? new Date(cupom.data_compra).toLocaleDateString('pt-BR') : 'N/A'
               ].join(","));
             }
           });
@@ -114,14 +106,11 @@ export default function Relatorios() {
       const headers = [
         "Cliente",
         "CPF",
-        "Telefone",
-        "Email",
-        "Número do Cupom",
         "Número da Sorte",
-        "Sorteio",
-        "Data do Sorteio",
+        "Série",
+        "WhatsApp",
         "Padaria",
-        "Data de Cadastro"
+        "Data da Compra"
       ];
       
       const csvContent = [headers.join(","), ...rows].join("\n");

--- a/src/pages/Relatorios.tsx
+++ b/src/pages/Relatorios.tsx
@@ -56,8 +56,8 @@ export default function Relatorios() {
     }
   });
 
-  // Exportar CSV de Participação
-  const generateParticipationCSV = async () => {
+  // Exportar XLSX de Participação
+  const generateParticipationXLSX = async () => {
     try {
       setIsExporting(true);
       toast.info("Gerando relatório de participação...");
@@ -83,49 +83,55 @@ export default function Relatorios() {
         return;
       }
 
-      // Processar dados no front
-      const rows: string[] = [];
+      const worksheetData = [
+        [
+          "Cliente",
+          "CPF",
+          "Número da Sorte",
+          "Série",
+          "WhatsApp",
+          "Padaria",
+          "Data da Compra"
+        ]
+      ];
+
       data.clientes.forEach(cliente => {
-        if (cliente && cliente.cupons && Array.isArray(cliente.cupons)) {
+        if (cliente?.cupons && Array.isArray(cliente.cupons)) {
           cliente.cupons.forEach(cupom => {
             if (cupom) {
-              rows.push([
-                `"${cliente.nome || 'N/A'}"`,
-                cliente.cpf || 'N/A',
-                cupom.numero_sorte || "N/A",
-                cupom.serie?.toString() || "N/A",
-                cliente.whatsapp || 'N/A',
-                cliente.padaria?.nome ? `"${cliente.padaria.nome}"` : "N/A",
-                cupom.data_compra ? new Date(cupom.data_compra).toLocaleDateString('pt-BR') : 'N/A'
-              ].join(","));
+              const numeroSorte = cupom.numero_sorte ? String(cupom.numero_sorte) : "N/A";
+              const serieValue = cupom.serie === 10 ? "0" : cupom.serie?.toString() || "N/A";
+              worksheetData.push([
+                cliente.nome || "N/A",
+                cliente.cpf || "N/A",
+                numeroSorte,
+                serieValue,
+                cliente.whatsapp || "N/A",
+                cliente.padaria?.nome || "N/A",
+                cupom.data_compra ? new Date(cupom.data_compra).toLocaleDateString("pt-BR") : "N/A"
+              ]);
             }
           });
         }
       });
 
-      const headers = [
-        "Cliente",
-        "CPF",
-        "Número da Sorte",
-        "Série",
-        "WhatsApp",
-        "Padaria",
-        "Data da Compra"
-      ];
-      
-      const csvContent = [headers.join(","), ...rows].join("\n");
-      const BOM = "\uFEFF";
-      const blob = new Blob([BOM + csvContent], { type: "text/csv;charset=utf-8;" });
-      const link = document.createElement("a");
-      const url = URL.createObjectURL(blob);
-      link.setAttribute("href", url);
-      link.setAttribute("download", `relatorio_participacao_${new Date().toISOString().split('T')[0]}.csv`);
-      link.style.visibility = "hidden";
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
+      const wb = XLSX.utils.book_new();
+      const ws = XLSX.utils.aoa_to_sheet(worksheetData);
 
-      toast.success(`Relatório exportado com ${rows.length} registros!`);
+      ws["!cols"] = [
+        { wch: 30 }, // Cliente
+        { wch: 16 }, // CPF
+        { wch: 18 }, // Número da Sorte
+        { wch: 8 },  // Série
+        { wch: 18 }, // WhatsApp
+        { wch: 30 }, // Padaria
+        { wch: 14 }  // Data da Compra
+      ];
+
+      XLSX.utils.book_append_sheet(wb, ws, "Participação");
+      XLSX.writeFile(wb, `relatorio_participacao_${new Date().toISOString().split("T")[0]}.xlsx`);
+
+      toast.success(`Relatório exportado com ${worksheetData.length - 1} registros!`);
     } catch (error) {
       toast.error("Erro ao gerar relatório");
     } finally {
@@ -331,10 +337,10 @@ export default function Relatorios() {
     {
       title: "Relatório de Participação",
       description: "Lista completa de clientes, cupons, número do sorteio, data e padaria",
-      format: ".CSV",
+      format: ".XLSX",
       icon: FileText,
       color: "text-secondary",
-      action: generateParticipationCSV
+      action: generateParticipationXLSX
     },
     {
       title: "Números Sorteados",

--- a/src/pages/Relatorios.tsx
+++ b/src/pages/Relatorios.tsx
@@ -89,7 +89,6 @@ export default function Relatorios() {
           "Cliente",
           "CPF",
           "Número da Sorte",
-          "Série",
           "WhatsApp",
           "Padaria",
           "Data da Compra"
@@ -102,11 +101,14 @@ export default function Relatorios() {
             if (cupom) {
               const numeroSorte = cupom.numero_sorte ? String(cupom.numero_sorte) : "N/A";
               const serieValue = cupom.serie === 10 ? "0" : cupom.serie?.toString() || "N/A";
+              const numeroSorteComSerie =
+                numeroSorte === "N/A" && serieValue === "N/A"
+                  ? "N/A"
+                  : `${serieValue}/${numeroSorte}`;
               worksheetData.push([
                 cliente.nome || "N/A",
                 cliente.cpf || "N/A",
-                numeroSorte,
-                serieValue,
+                numeroSorteComSerie,
                 cliente.whatsapp || "N/A",
                 cliente.padaria?.nome || "N/A",
                 cupom.data_compra ? new Date(cupom.data_compra).toLocaleDateString("pt-BR") : "N/A"


### PR DESCRIPTION
### Motivation
- Corrigir exportação de participação para incluir os dados reais de sorteio que estavam aparecendo como `N/A` na planilha. 
- Garantir que a consulta GraphQL retorne `numero_sorte` e `serie` dos cupons para popular o CSV corretamente.

### Description
- Expandida a query `GET_ALL_CLIENTES_WITH_CUPONS` para incluir `padaria { nome }`, `cupons.numero_sorte` e `cupons.serie` em `src/graphql/queries.ts`.
- Atualizado `src/pages/Relatorios.tsx` para consumir os novos campos e ajustar o mapeamento de exportação: agora usa `cliente.whatsapp`, `cliente.padaria.nome`, `cupom.serie` e `cupom.data_compra` no CSV em vez de campos inexistentes como `numero_cupom`/`sorteio`.
- Atualizados os cabeçalhos do CSV para refletir `Número da Sorte`, `Série`, `WhatsApp`, `Padaria` e `Data da Compra`.

### Testing
- Nenhum teste automatizado foi executado durante esta alteração.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d40964f64832a92c178af10aff86e)