### PR TITLE
Remove limit from padaria clientes export query

### DIFF
--- a/src/components/padaria/ClientesTable.tsx
+++ b/src/components/padaria/ClientesTable.tsx
@@ -28,9 +28,7 @@ export function ClientesTable() {
     ['clientes-by-padaria', padariasId],
     GET_CLIENTES,
     {
-      padaria_id: padariasId,
-      limit: 100,
-      offset: 0
+      padaria_id: padariasId
     },
     { enabled: !!padariasId }
   );


### PR DESCRIPTION
### Motivation
- Exports were capped at 100 rows because the `GET_CLIENTES` request included `limit: 100` and `offset: 0`, so the query must be unlimited to allow exporting all clients.

### Description
- Removed the `limit`/`offset` variables from the `GET_CLIENTES` call in `src/components/padaria/ClientesTable.tsx` so the GraphQL query retrieves all clients for the padaria.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697904b6d434832aa1981effe9ca591d)